### PR TITLE
Add notes on multiple schemes to have a centralized namelist read scheme

### DIFF
--- a/docs/conversion/create-namelist-xml.md
+++ b/docs/conversion/create-namelist-xml.md
@@ -66,6 +66,6 @@ The namelist options scheme can follow the pattern of the [zm_conv_options](http
 * Only a `init` phase is needed, e.g., `zm_conv_options_init`. Only having an `init` phase dedicated for namelist parameters, and no other compute, allows for these namelist variables to be read without having to run any logic for a particular scheme;
 * The namelist XML file is attached to this module, e.g., `zm_conv_options_namelist.xml`.
 
-Once this scheme is added to the SDF, namelist quantities defined in this namelist.xml are just regular CCPP quantities, i.e., they can be retrieved directly via their standard name as inputs to other physics schemes. There is no need to `use` variables from this namelist read module.
+Once this scheme is added to the SDF, namelist quantities defined in the associated `<scheme>_namelist.xml` file are just regular CCPP quantities, i.e., they can be retrieved directly via their standard name as inputs to other physics schemes. There is no need to `use` variables from this namelist read module.
 
 Once you have made your namelist file, proceed to [4 - Interstitials](interstitials.md)

--- a/docs/conversion/create-namelist-xml.md
+++ b/docs/conversion/create-namelist-xml.md
@@ -63,7 +63,7 @@ For physics parameterizations that are split into multiple CCPP schemes (within 
 
 The namelist options scheme can follow the pattern of the [zm_conv_options](https://github.com/ESCOMP/atmospheric_physics/blob/main/schemes/zhang_mcfarlane/zm_conv_options.F90) scheme used for reading Zhang-McFarlane deep convective namelist options:
 * The namelist options scheme **has to be in a separate module file**, e.g., `zm_conv_options.F90` and `zm_conv_options.meta`. No other CCPP schemes can be in the same module;
-* Only a `init` phase is needed, e.g., `zm_conv_options_init`. Only having an `init` phase dedicated for namelist parameters, and no other compute, allows for these namelist variables to be read without having to run any logic for a particular scheme;
+* Only an `init` phase is needed, e.g., `zm_conv_options_init`. Only having an `init` phase dedicated for namelist parameters, and no other compute, allows for these namelist variables to be read without having to run any logic for a particular scheme;
 * The namelist XML file is attached to this module, e.g., `zm_conv_options_namelist.xml`.
 
 Once this scheme is added to the SDF, namelist quantities defined in the associated `<scheme>_namelist.xml` file are just regular CCPP quantities, i.e., they can be retrieved directly via their standard name as inputs to other physics schemes. There is no need to `use` variables from this namelist read module.

--- a/docs/conversion/create-namelist-xml.md
+++ b/docs/conversion/create-namelist-xml.md
@@ -57,5 +57,15 @@ The CCPP Framework will autogenerate the namelist reader based on the elements i
 !!!Note "namelist values"
     When porting namelist values from CAM namelist defaults, the attributes supported in CAM-SIMA can be retrieved by printing out `cam_nml_dict` (or `cam_nml_dict.keys()`) in `cime_config/buildnml` [at the end of the function call](https://github.com/ESCOMP/CAM-SIMA/blob/3699359ebfe81b00273a9815d128cae903a26208/cime_config/buildnml#L355). An example of supported attributes that may be commonly used are: `phys_suite`, `ic_ymd`, `dyn`, `hgrid`, `analytic_ic`, `ocn`.
 
+## For physics schemes split into multiple CCPP schemes, have a dedicated namelist read scheme
+
+For physics parameterizations that are split into multiple CCPP schemes (within a single or several modules), create a dedicated namelist options scheme to centralize namelist variable reading. This approach makes dependencies on namelist variables explicit, including in the case where another physics scheme depends on the namelist variables of another physics scheme (e.g., Hack shallow convection on ZM deep convection options.) and facilitates future centralized modifications of namelist parameters for a physical scheme by scientists.
+
+The namelist options scheme can follow the pattern of the [zm_conv_options](https://github.com/ESCOMP/atmospheric_physics/blob/main/schemes/zhang_mcfarlane/zm_conv_options.F90) scheme used for reading Zhang-McFarlane deep convective namelist options:
+* The namelist options scheme **has to be in a separate module file**, e.g., `zm_conv_options.F90` and `zm_conv_options.meta`. No other CCPP schemes can be in the same module;
+* Only a `init` phase is needed, e.g., `zm_conv_options_init`. Only having an `init` phase dedicated for namelist parameters, and no other compute, allows for these namelist variables to be read without having to run any logic for a particular scheme;
+* The namelist XML file is attached to this module, e.g., `zm_conv_options_namelist.xml`.
+
+Once this scheme is added to the SDF, namelist quantities defined in this namelist.xml are just regular CCPP quantities, i.e., they can be retrieved directly via their standard name as inputs to other physics schemes. There is no need to `use` variables from this namelist read module.
 
 Once you have made your namelist file, proceed to [4 - Interstitials](interstitials.md)

--- a/docs/conversion/create-namelist-xml.md
+++ b/docs/conversion/create-namelist-xml.md
@@ -59,7 +59,7 @@ The CCPP Framework will autogenerate the namelist reader based on the elements i
 
 ## For physics schemes split into multiple CCPP schemes, have a dedicated namelist read scheme
 
-For physics parameterizations that are split into multiple CCPP schemes (within a single or several modules), create a dedicated namelist options scheme to centralize namelist variable reading. This approach makes dependencies on namelist variables explicit, including in the case where another physics scheme depends on the namelist variables of another physics scheme (e.g., Hack shallow convection on ZM deep convection options.) and facilitates future centralized modifications of namelist parameters for a physical scheme by scientists.
+For physics parameterizations that are split into multiple CCPP schemes (within a single or several modules), create a dedicated namelist options scheme to centralize namelist variable reading. This approach makes dependencies on namelist variables explicit, including in the case where a physics scheme depends on the namelist variables of another, different physics scheme (e.g., Hack shallow convection using ZM deep convection namelist options.) and facilitates future centralized modifications of namelist parameters for a physical scheme by scientists.
 
 The namelist options scheme can follow the pattern of the [zm_conv_options](https://github.com/ESCOMP/atmospheric_physics/blob/main/schemes/zhang_mcfarlane/zm_conv_options.F90) scheme used for reading Zhang-McFarlane deep convective namelist options:
 * The namelist options scheme **has to be in a separate module file**, e.g., `zm_conv_options.F90` and `zm_conv_options.meta`. No other CCPP schemes can be in the same module;


### PR DESCRIPTION
Following discussion (with @cacraigucar @peverwhee @nusbaume) at today's meeting, adding a note that if a physics parameterization is split into multiple CCPP schemes, it could be good practice to have a dedicated scheme for namelist variable reading.

I'm proposing to add some notes to note down what we've discussed. Opening this as a PR so we could edit this to reflect our consensus. Suggestions welcome!